### PR TITLE
Fix for issue #107

### DIFF
--- a/app/assets/javascripts/components/page_editor.js.jsx
+++ b/app/assets/javascripts/components/page_editor.js.jsx
@@ -88,7 +88,11 @@ class PageEditor extends React.Component {
   }
 
   onChangeTriples(triples) {
-    var pageWithoutMetadata = this.state.rawContent.substring(0, this.state.rawContent.indexOf('== Metadata =='));
+    var indexMetadata = this.state.rawContent.indexOf('== Metadata ==');
+    var pageWithoutMetadata = this.state.rawContent;
+    if (-1 !== indexMetadata) {
+        pageWithoutMetadata = this.state.rawContent.substring(0, indexMetadata);
+    }
 
     var metadata = '== Metadata ==\n\n' + triples.map(function(triple) {
       return '* [[' + triple.predicate + '::' + triple.object + ']]';


### PR DESCRIPTION
indexOf returns -1 if the pattern can't be found. substring(0, -1) returns an
empty string. This fix keeps the content even if `== Metadata ==' is not found.